### PR TITLE
Update php package repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ CMD ["/sbin/my_init"]
 RUN \
 	export LANG=C.UTF-8 && \
 	add-apt-repository ppa:mc3man/trusty-media && \
-	add-apt-repository ppa:ondrej/php5-5.6 && \
+	add-apt-repository ppa:ondrej/php && \
 	add-apt-repository -y ppa:nginx/stable && \
 	add-apt-repository -y ppa:rwky/graphicsmagick && \
 	apt-get update && \


### PR DESCRIPTION
`ppa:ondrej/php5-5.6` is deprecated, use `ppa:ondrej/php5` instead.

[PPA migration to ppa:ondrej php ](https://github.com/oerdnj/deb.sury.org/wiki/PPA-migration-to-ppa:ondrej-php)

Current Dockerfile causes the build to fail:

```
Cannot add PPA: 'ppa:ondrej/php5-5.6'.
Please check that the PPA name or format is correct.
```